### PR TITLE
Added script to automate plenary reports

### DIFF
--- a/data/input/readme.md
+++ b/data/input/readme.md
@@ -1,3 +1,13 @@
 The PDFs in this folder are all full reports of the plenary gatherings of the chamber of the Belgian federal government, since the start of 2024, until April 4th (last update of this folder).
 
-They have been downloaded manually (for now) from https://www.dekamer.be/kvvcr/showpage.cfm?section=/cricra&language=nl&cfm=dcricra.cfm?type=plen&cricra=cri&count=all.
+You can download them manually or use the download script.
+
+## Manual download
+
+Go to [https://www.dekamer.be/kvvcr/showpage.cfm?section=/cricra&language=nl&cfm=dcricra.cfm?type=plen&cricra=cri&count=all](this page) and download the pdfs and/or html files.
+
+## Using the download script
+
+Run the following command. You can specify the maximum document number, default is 300
+
+    ./download-reports.sh

--- a/download-reports.sh
+++ b/download-reports.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+download_plenary_report_pdf() {
+  to=${1:300}
+  for i in $(seq -w 300); do
+    curl https://www.dekamer.be/doc/PCRI/pdf/55/ip$i.pdf -o data/input/ip${i}.pdf
+  done
+}
+
+download_plenary_report_html() {
+  to=${1:300}
+  for i in $(seq -w 300); do
+    curl https://www.dekamer.be/doc/PCRI/html/55/ip289x.html -o data/input/ip${i}x.html
+  done
+}
+
+max_plenary_nr=${1:-300}
+download_plenary_report_pdf ${max_plenary_nr}
+download_plenary_report_html ${max_plenary_nr}

--- a/readme.md
+++ b/readme.md
@@ -6,7 +6,7 @@ This project currently visualizes the voting behavior of the politicians in the 
 
 ## First prototype: textual summary of recent voting behavior
 
-As a first visualization, the fetched voting behavior is summarized as text in https://github.com/transparentdemocracy/voting-data/tree/main/data/output, per plenary session in the Chamber.
+As a first visualization, the fetched voting behavior is summarized as text in [this directory](https://github.com/transparentdemocracy/voting-data/tree/main/data/output), per plenary session in the Chamber.
 
 
 ## Next prototype: a voting quiz

--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 import glob
 import os
 import logging
+from bs4 import BeautifulSoup
 
 from voting_serializers import MotionToMarkdownSerializer
 from voting_extractors import FederalChamberVotingExtractor
@@ -12,8 +13,11 @@ logging.basicConfig(level=logging.INFO) # or DEBUG to see debugging info as well
 INPUT_REPORTS_PATH = "../data/input"
 OUTPUT_MARKDOWN_PATH = "../data/output"
 
+def main():
+    #convert_to_markdown()
+    convert_to_json()
 
-if __name__ == "__main__":
+def convert_to_markdown():
     # Process all input reports:
     input_reports = glob.glob(os.path.join(INPUT_REPORTS_PATH, "*.pdf"))
     logging.debug(f"Will process the following input reports: {input_reports}.")
@@ -30,4 +34,16 @@ if __name__ == "__main__":
             plenary_number = int(output_markdown_file_name.split(".pdf")[0].replace("ip", ""))
             voting_serializer.serialize_motions(motions, plenary_number, os.path.join(OUTPUT_MARKDOWN_PATH, f"plenary {plenary_number}.md"))
         except Exception as e:
-            logging.warn(e) # TODO rare errors to fix + in some pdfs, no motions could be extracted - to fix.
+            logging.warning(e) # TODO rare errors to fix + in some pdfs, no motions could be extracted - to fix.
+
+def convert_to_json():
+    input_reports = glob.glob(os.path.join(INPUT_REPORTS_PATH, "*.html"))
+    logging.debug(f"Processing {len(input_reports)} reports.")
+    for report in input_reports:
+        print("report",report)
+        motions = voting_extractor.extract_html(input_report)
+
+        JsonVotingSerializer().serialize(motions)
+
+if __name__ == "__main__":
+    main()

--- a/src/test_voting_extractors.py
+++ b/src/test_voting_extractors.py
@@ -1,0 +1,24 @@
+from voting_extractors import FederalChamberVotingPdfExtractor
+from model import Motion, Proposal
+
+import unittest
+
+class TestFederalChamberVotingPdfExtractor(unittest.TestCase):
+    
+    def test_extract(self):
+        actual = FederalChamberVotingPdfExtractor().extract('../data/input/ip298.pdf')
+
+        self.assertEqual(len(actual), 13)
+        self.assertEqual(actual[0].proposal.number, 10)
+        expected_description = 'Motions déposées en conclusion'
+        self.assertEqual(actual[0].proposal.description[:len(expected_description)], expected_description)
+        self.assertEqual(actual[0].num_votes_yes,16) 
+        self.assertEqual(len(actual[0].vote_names_yes),16)
+        self.assertEqual(actual[0].vote_names_yes[:2], ['Bury Katleen', 'Creyelman Steven'])
+        self.assertEqual(actual[0].num_votes_no,116)
+        self.assertEqual(len(actual[0].vote_names_no),116)
+        self.assertEqual(actual[0].vote_names_no[:2],["Anseeuw Björn","Aouasti Khalil"])
+        self.assertEqual(actual[0].num_votes_abstention,1)
+        self.assertEqual(actual[0].vote_names_abstention,['Özen Özlem'])
+        self.assertEqual(actual[0].cancelled,False)
+

--- a/src/voting_extractors.py
+++ b/src/voting_extractors.py
@@ -11,7 +11,7 @@ logger = logging.getLogger(__name__)
 # logging.basicConfig(level=logging.INFO) # or DEBUG for debugging info. To write to file: filename='example.log', encoding='utf-8', 
 
 
-class FederalChamberVotingExtractor():
+class FederalChamberVotingPdfExtractor():
 	"""
 	Extract voting behavior from a voting report on the Belgian federal chamber's website,
 	for example at https://www.dekamer.be/kvvcr/showpage.cfm?section=/flwb/recent&language=nl&cfm=/site/wwwcfm/flwb/LastDocument.cfm.
@@ -242,7 +242,7 @@ class FederalChamberVotingExtractor():
 
 
 if __name__ == "__main__":
-	voting_extractor = FederalChamberVotingExtractor()
+	voting_extractor = FederalChamberVotingPdfExtractor()
 
 	# Inspect a page:
 	voting_extractor.print_page("../data/input/ip298.pdf", 0)


### PR DESCRIPTION
- Added script to automatically download plenary reports
- Added 'Pdf' to the name of the voting extractor to make clear what its inputs are (and to make room for Html later
- Added unit test for voting extraction
- Minor readme improvements

Note: earlier experiments bumped into captchas while mass downloading from www.dekamer.be, but it seems to work for plenary reports.