### PR TITLE
Change paths in download script + parsing proposal description in html

### DIFF
--- a/download-reports.sh
+++ b/download-reports.sh
@@ -3,14 +3,14 @@
 download_plenary_report_pdf() {
   to=${1:300}
   for i in $(seq -w 300); do
-    curl https://www.dekamer.be/doc/PCRI/pdf/55/ip$i.pdf -o data/input/ip${i}.pdf
+    curl https://www.dekamer.be/doc/PCRI/pdf/55/ip$i.pdf -o data/input/pdf/ip${i}.pdf
   done
 }
 
 download_plenary_report_html() {
   to=${1:300}
   for i in $(seq -w 300); do
-    curl https://www.dekamer.be/doc/PCRI/html/55/ip${i}x.html -o data/input/ip${i}x.html
+    curl https://www.dekamer.be/doc/PCRI/html/55/ip${i}x.html -o data/input/html/ip${i}x.html
   done
 }
 

--- a/src/model.py
+++ b/src/model.py
@@ -17,18 +17,11 @@ class Politician:
 
 @dataclass
 class Proposal:
-    number: int
+    id: str
     description: str
-
-
-@dataclass
-class MotionId:
-    report: str
-    nr: int
 
 @dataclass
 class Motion:
-    id: MotionId
     proposal: Proposal
     num_votes_yes: int
     vote_names_yes: List[str]
@@ -38,6 +31,11 @@ class Motion:
     vote_names_abstention: List[str]
     cancelled: bool
     parse_problems: list[str] = field(default_factory=list)
+
+@dataclass
+class Plenary:
+    session_nr: int
+    motions: list[Motion]
 
 class VoteType(Enum):
     YES = "YES"

--- a/src/test_voting_extractors.py
+++ b/src/test_voting_extractors.py
@@ -2,14 +2,13 @@ import logging
 import os
 import unittest
 
-import sys
-
-from src.model import ParseProblem
+from src.model import Proposal
 from voting_extractors import FederalChamberVotingPdfExtractor, FederalChamberVotingHtmlExtractor, TokenizedText, \
 	find_sequence, find_occurrences
 
 logger = logging.getLogger(__name__)
 logging.basicConfig(level=logging.DEBUG)
+logger.setLevel(logging.DEBUG)
 
 
 class TestFederalChamberVotingPdfExtractor(unittest.TestCase):
@@ -19,7 +18,7 @@ class TestFederalChamberVotingPdfExtractor(unittest.TestCase):
 
 		self.assertEqual(13, len(actual))
 
-		self.assertEqual(10, actual[0].proposal.number)
+		self.assertEqual(10, actual[0].proposal.id)
 		expected_description = 'Motions déposées en conclusion des  interpellations de'
 		self.assertEqual(expected_description, actual[0].proposal.description[:len(expected_description)])
 
@@ -46,7 +45,7 @@ class TestFederalChamberVotingHtmlExtractor(unittest.TestCase):
 
 		self.assertEqual(len(actual), 300)
 
-		all_motions = [motion for motions in actual.values() for motion in motions]
+		all_motions = [motion for plenary in actual for motion in plenary.motions]
 		self.assertEqual(len(all_motions), 2842)
 
 		motions_with_problems = list(filter(lambda m: len(m.parse_problems) > 0, all_motions))
@@ -55,20 +54,29 @@ class TestFederalChamberVotingHtmlExtractor(unittest.TestCase):
 		self.assertEqual(len(motions_with_problems), 17)
 
 	def test_extract_ip67(self):
-		actual = FederalChamberVotingHtmlExtractor().extract('../data/input/html/ip067x.html')
+		actual = FederalChamberVotingHtmlExtractor().parse_plenary_report('../data/input/html/ip067x.html')
 
-		self.assertEqual(len(actual), 18)
-		self.assertEqual(actual[0].parse_problems,
+		self.assertEqual(len(actual.motions), 18)
+		self.assertEqual(actual.motions[0].parse_problems,
 						 ["vote count (51) does not match voters []"])
 
-	def test_extract_ip298(self):
-		actual = FederalChamberVotingHtmlExtractor().extract('../data/input/html/ip298x.html')
+	def test_extract_ip72(self):
+		"""vote 2 has an extra '(' in the vote result indicator"""
+		actual = FederalChamberVotingHtmlExtractor().parse_plenary_report('../data/input/html/ip072x.html')
 
-		self.assertEqual(28, len(actual))
-		# self.assertEqual(10, actual[0].proposal.number)
-		# expected_description = 'Motions déposées en conclusion'
-		# self.assertEqual(expected_description, actual[0].proposal.description[:len(expected_description)])
-		motion0 = actual[0]
+		self.assertEqual(len(actual.motions), 5)
+
+	def test_extract_ip298(self):
+		actual = FederalChamberVotingHtmlExtractor().parse_plenary_report('../data/input/html/ip298x.html')
+
+		self.assertEqual(28, len(actual.motions))
+		self.assertEqual(actual.motions[0].proposal.id, "1")
+
+		# TODO: there's introductory stuff here that shouldn't be part of the proposal description
+		expected_description_start = "\nVotes\nnominatifs\nVotes\nnominatifs\n\n\xa0\n\xa0\n\xa0\n09.02 \xa0Sofie Merckx (PVDA-PTB): Mevrouw de voorzitster, mevrouw Verhaert moest ons\nverlaten en mevrouw Daems zal haar stemgedrag daarvoor aanpassen."
+		self.assertEqual(actual.motions[0].proposal.description[:len(expected_description_start)],
+						 expected_description_start)
+		motion0 = actual.motions[0]
 
 		self.assertEqual(79, motion0.num_votes_yes)
 		self.assertEqual(79, len(motion0.vote_names_yes))
@@ -83,7 +91,7 @@ class TestFederalChamberVotingHtmlExtractor(unittest.TestCase):
 		self.assertEqual(['Arens Josy', 'Daems Greet'], motion0.vote_names_abstention[:2])
 
 		self.assertEqual(False, motion0.cancelled)
-		self.assertEqual(True, actual[11].cancelled)
+		self.assertEqual(True, actual.motions[11].cancelled)
 
 
 class TestTokenizedText(unittest.TestCase):


### PR DESCRIPTION
Scripts were updated to expect data/input/pdf and data/input/html but download script wasn't changed.

Extracting proposal description would make html parsing feature complete and theoretically allow to replaced and remove PDF parsing next